### PR TITLE
feat: add env variables from secrets

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.9.2
+version: 0.9.3
 appVersion: 2.15.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/_api_environment.yaml
+++ b/charts/flagsmith/templates/_api_environment.yaml
@@ -51,6 +51,13 @@
 - name: {{ $envName }}
   value: {{ $envValue | quote }}
 {{- end }}
+{{- range $envName, $secretKeyRef := .Values.api.extraEnvFromSecret }}
+- name: {{ $envName }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretKeyRef.secretName }}
+      key: {{ $secretKeyRef.secretKey }}
+{{- end }}
 {{- if .Values.frontend.apiProxy.enabled }}
 - name: USE_X_FORWARDED_HOST
   value: 'true'

--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -222,6 +222,13 @@ Frontend environment
 - name: {{ $envName }}
   value: {{ $envValue | quote }}
 {{- end }}
+{{- range $envName, $secretKeyRef := .Values.frontend.extraEnvFromSecret }}
+- name: {{ $envName }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretKeyRef.secretName }}
+      key: {{ $secretKeyRef.secretKey }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -24,6 +24,11 @@ api:
   #   memory: 300Mi
   podLabels: {}
   extraEnv: {}
+  # extraEnvFromSecret:
+  #   NAME:
+  #    secretName: mysecret
+  #    secretKey: mykey
+  extraEnvFromSecret: {}
   # See https://docs.flagsmith.com/deployment/locally-api#creating-a-secret-key
   secretKey: null
   nodeSelector: {}
@@ -76,6 +81,7 @@ frontend:
   apiProxy:
     enabled: true
   extraEnv: {}
+  extraEnvFromSecret: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -25,7 +25,7 @@ api:
   podLabels: {}
   extraEnv: {}
   # extraEnvFromSecret:
-  #   NAME:
+  #   ENV_NAME:
   #    secretName: mysecret
   #    secretKey: mykey
   extraEnvFromSecret: {}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version`

## Changes

Some environment variables are sensitive (for example, Sendgrid API Key). In our environments we manage secrets separatedly from the helm charts. With this change, we will be able to create secrets and reference them as environment variables in the Flagsmith API and Frontend deployments. 

## How did you test this code?

I ran `helm template flagsmith . -f values.yaml` and inspected the resulting templates. I verified that the environment variables were added. 